### PR TITLE
chore: tested Vite and Galaxy

### DIFF
--- a/packages/vite-bundler/README.md
+++ b/packages/vite-bundler/README.md
@@ -15,7 +15,7 @@ Use [Vite](https://vitejs.dev) in your Meteor app! ⚡️
   - [ ] Re-exports via intermediary variable (not tested)
 - [x] Code-splitting/Dynamic imports
 - [ ] SSR (not tested)
-- [ ] Galaxy deployment (not tested)
+- [x] Galaxy deployment [link](https://vite-and-vue3.meteorapp.com/)
 
 ## Installation
 


### PR DESCRIPTION
I've tested standard deployment for meteor & Vite & Vue 3, and here are the results:
Site link: https://vite-and-vue3.meteorapp.com/
Command that I've run:

```bash

meteor deploy vite-and-vue3.meteorapp.com --mongo --free

```
Have not tested SSR yet.
 Really cool having acess to Vite ecossytem! Thanks for this awesome work @Akryum 