### PR TITLE
fix(build): use `meteor node` command instead of `node`

### DIFF
--- a/packages/vite-bundler/build.js
+++ b/packages/vite-bundler/build.js
@@ -259,7 +259,8 @@ try {
   fs.ensureDirSync(path.dirname(viteOutDir))
 
   // Build with vite
-  const result = execaSync('node', [
+  const result = execaSync('meteor', [
+    'node',
     workerFile,
   ], {
     cwd,


### PR DESCRIPTION
Closes #18 and [this one](https://github.com/disney/meteor-base/issues/129).

This PR replaces `node XXX` command with `meteor node XXX` in [`vite-bundler/build.js`](https://github.com/Akryum/meteor-vite/blob/1565ded19782706238a96be3f0380f08a72a4bac/packages/vite-bundler/build.js#L262), as described in [this comment](https://github.com/disney/meteor-base/issues/129#issuecomment-1329777531).

This is a small but very critical fix for those using [meteor-base](https://github.com/disney/meteor-base) docker image. The building is not possible without it. @Akryum , please review it, it's just 2 lines.